### PR TITLE
完成User、Template和TemplateItem数据库相关操作

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .gradle
 /local.properties
+/.idea/misc.xml
 /.idea/caches
 /.idea/.name
 /.idea/libraries

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <configuration PROFILE_NAME="Debug" CONFIG_NAME="Debug" />
     </configurations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/MainActivity.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/MainActivity.java
@@ -6,6 +6,12 @@ import androidx.navigation.Navigation;
 import androidx.navigation.ui.NavigationUI;
 
 import android.os.Bundle;
+import android.util.Log;
+
+import comv.example.zyrmj.precious_time01.entity.Template;
+import comv.example.zyrmj.precious_time01.entity.User;
+import comv.example.zyrmj.precious_time01.repository.TemplateRepository;
+import comv.example.zyrmj.precious_time01.repository.UserRepository;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -15,6 +21,15 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         NavController controller= Navigation.findNavController(this,R.id.fragment);
         NavigationUI.setupActionBarWithNavController(this,controller);
+
+
+        User user = new User();
+        User user2 = new User();
+        user2.setId("2");
+        new UserRepository(this).insertUsers(user, user2);
+        Template t = new Template("offline", "study");
+        Template t2 = new Template("2", "study");
+        new TemplateRepository(this).insertTemplates(t, t2);
     }
 
     @Override

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/RegisterFragment.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/RegisterFragment.java
@@ -10,6 +10,15 @@ import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 import comv.example.zyrmj.precious_time01.BackendService.RegisterAndLoginBackendService;
 import comv.example.zyrmj.precious_time01.Utils.MD5Util;
+
+import comv.example.zyrmj.precious_time01.dao.CategoryDao;
+import comv.example.zyrmj.precious_time01.dao.HabitDao;
+import comv.example.zyrmj.precious_time01.database.AppDatabase;
+import comv.example.zyrmj.precious_time01.entity.Category;
+import comv.example.zyrmj.precious_time01.entity.Template;
+import comv.example.zyrmj.precious_time01.entity.TemplateItem;
+import comv.example.zyrmj.precious_time01.entity.User;
+import comv.example.zyrmj.precious_time01.repository.TemplateItemRepository;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/dao/HabitDao.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/dao/HabitDao.java
@@ -14,3 +14,4 @@ public interface HabitDao {
     void insert(Habit category);
 }
 
+

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/dao/TemplateDao.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/dao/TemplateDao.java
@@ -1,0 +1,24 @@
+package comv.example.zyrmj.precious_time01.dao;
+
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Update;
+
+import java.util.List;
+
+import comv.example.zyrmj.precious_time01.entity.Template;
+
+@Dao
+public interface TemplateDao {
+    @Insert
+    void insertTemplate(Template... templates);
+    @Delete
+    void deleteTemplate(Template... templateItems);
+    @Update
+    void updateTemplate(Template... templateItems);
+    @Query("Select * from Template")
+    LiveData<List<Template>> getAllTemplates();
+}

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/dao/TemplateItemDao.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/dao/TemplateItemDao.java
@@ -1,0 +1,25 @@
+package comv.example.zyrmj.precious_time01.dao;
+
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Update;
+
+import java.util.List;
+
+import comv.example.zyrmj.precious_time01.entity.Template;
+import comv.example.zyrmj.precious_time01.entity.TemplateItem;
+
+@Dao
+public interface TemplateItemDao {
+    @Insert
+    void insertTemplateItem(TemplateItem... templateItems);
+    @Delete
+    void deleteTemplateItem(TemplateItem... templateItems);
+    @Update
+    void updateTemplateItem(TemplateItem... templateItems);
+    @Query("Select * from TemplateItem")
+    LiveData<List<TemplateItem>>getAllTemplateItems();
+}

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/dao/UserDao.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/dao/UserDao.java
@@ -1,0 +1,24 @@
+package comv.example.zyrmj.precious_time01.dao;
+
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Update;
+
+import java.util.List;
+
+import comv.example.zyrmj.precious_time01.entity.User;
+
+@Dao
+public interface UserDao {
+    @Insert
+    void insertUser(User... users);
+    @Update
+    void updateUser(User... users);
+    @Delete
+    void deleteUser(User... users);
+    @Query("select * from User")
+    LiveData<List<User>>getAllUsers();
+}

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/database/AppDatabase.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/database/AppDatabase.java
@@ -7,6 +7,7 @@ import androidx.room.RoomDatabase;
 
 import comv.example.zyrmj.precious_time01.dao.CategoryDao;
 import comv.example.zyrmj.precious_time01.dao.HabitDao;
+import comv.example.zyrmj.precious_time01.dao.TemplateItemDao;
 import comv.example.zyrmj.precious_time01.entity.Category;
 import comv.example.zyrmj.precious_time01.entity.Habit;
 import comv.example.zyrmj.precious_time01.entity.Quote;
@@ -15,11 +16,21 @@ import comv.example.zyrmj.precious_time01.entity.TemplateItem;
 import comv.example.zyrmj.precious_time01.entity.Todo;
 import comv.example.zyrmj.precious_time01.entity.User;
 
+import static android.net.wifi.rtt.CivicLocationKeys.ROOM;
+
 //Singleton
 @Database(entities = {Category.class, Habit.class, Quote.class, Template.class, TemplateItem.class,
         Todo.class, User.class}, version = 1,exportSchema = false)
 public abstract class AppDatabase extends RoomDatabase {
-
+    private static AppDatabase INSTANCE;
+    public static synchronized AppDatabase getDatabase(Context context) {
+        if(INSTANCE == null) {
+            INSTANCE = Room.databaseBuilder(context.getApplicationContext(), AppDatabase.class, "time_db")
+                    .build();
+        }
+        return INSTANCE;
+    }
     public abstract CategoryDao categoryDao();
+    public abstract TemplateItemDao templateItemDao();
     public abstract HabitDao habitDao();
 }

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/database/AppDatabase.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/database/AppDatabase.java
@@ -7,7 +7,9 @@ import androidx.room.RoomDatabase;
 
 import comv.example.zyrmj.precious_time01.dao.CategoryDao;
 import comv.example.zyrmj.precious_time01.dao.HabitDao;
+import comv.example.zyrmj.precious_time01.dao.TemplateDao;
 import comv.example.zyrmj.precious_time01.dao.TemplateItemDao;
+import comv.example.zyrmj.precious_time01.dao.UserDao;
 import comv.example.zyrmj.precious_time01.entity.Category;
 import comv.example.zyrmj.precious_time01.entity.Habit;
 import comv.example.zyrmj.precious_time01.entity.Quote;
@@ -32,5 +34,7 @@ public abstract class AppDatabase extends RoomDatabase {
     }
     public abstract CategoryDao categoryDao();
     public abstract TemplateItemDao templateItemDao();
+    public abstract TemplateDao templateDao();
     public abstract HabitDao habitDao();
+    public abstract UserDao userDao();
 }

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/entity/Category.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/entity/Category.java
@@ -7,12 +7,12 @@ import androidx.room.Index;
 import androidx.room.PrimaryKey;
 
 
-@Entity(primaryKeys = {"user_id","name"},indices = @Index(value = "name",unique = true))
+@Entity(primaryKeys = {"user_id", "name"}, indices = @Index(value = "name", unique = true))
 public class Category {
     @ColumnInfo(name = "user_id")
     @NonNull
     public String userId;
-   @NonNull
+    @NonNull
     public String name;
 
     public String getUserId() {

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/entity/Template.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/entity/Template.java
@@ -14,6 +14,11 @@ public class Template {
     @ColumnInfo(name = "user_id")
     private String userId;
 
+    public Template(@NonNull String userId, @NonNull String name) {
+        this.userId = userId;
+        this.name = name;
+    }
+
     @NonNull
     public String getUserId() {
         return userId;

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/entity/Template.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/entity/Template.java
@@ -4,15 +4,16 @@ import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.ForeignKey;
+import androidx.room.Index;
 
 @Entity(primaryKeys = {"user_id", "name"},
-        foreignKeys = @ForeignKey(entity = User.class,
-                parentColumns = "id",
-                childColumns = "user_id"))
+        foreignKeys = @ForeignKey(entity = User.class, parentColumns = "id", childColumns = "user_id"))
 public class Template {
     @NonNull
     @ColumnInfo(name = "user_id")
     private String userId;
+    @NonNull
+    private String name;
 
     public Template(@NonNull String userId, @NonNull String name) {
         this.userId = userId;
@@ -36,8 +37,5 @@ public class Template {
     public void setName(@NonNull String name) {
         this.name = name;
     }
-
-    @NonNull
-    private  String name;
 
 }

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/entity/TemplateItem.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/entity/TemplateItem.java
@@ -4,22 +4,21 @@ import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.ForeignKey;
+import androidx.room.Index;
 
 @Entity(primaryKeys = {"user_id", "item_name"}, foreignKeys = {@ForeignKey(entity = User.class, parentColumns = "id", childColumns = "user_id"),
-        @ForeignKey(entity = Template.class, parentColumns = "name", childColumns = "template_name")})
+        },
+        indices = {@Index(value = "template_name")})
 public class TemplateItem {
     @NonNull
     @ColumnInfo(name = "user_id")
-    @ForeignKey(entity = User.class, parentColumns = "id", childColumns = "user_id")
     private String userId;
     @NonNull
     @ColumnInfo(name = "item_name")
     private  String itemName;
     @ColumnInfo(name = "template_name")
-    @ForeignKey(entity = Template.class, parentColumns = "name", childColumns = "template_name")
     private  String templateName;
     @ColumnInfo(name = "category_name")
-    @ForeignKey(entity = Category.class, parentColumns = "name", childColumns = "category_name")
     private String categoryName;
     @ColumnInfo(name = "end_time")
     private String endTime;

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/entity/TemplateItem.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/entity/TemplateItem.java
@@ -5,7 +5,8 @@ import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.ForeignKey;
 
-@Entity(primaryKeys = {"user_id", "item_name"})
+@Entity(primaryKeys = {"user_id", "item_name"}, foreignKeys = {@ForeignKey(entity = User.class, parentColumns = "id", childColumns = "user_id"),
+        @ForeignKey(entity = Template.class, parentColumns = "name", childColumns = "template_name")})
 public class TemplateItem {
     @NonNull
     @ColumnInfo(name = "user_id")
@@ -47,8 +48,18 @@ public class TemplateItem {
         return templateName;
     }
 
-    public void setTemplateName(String habitName) {
-        this.templateName = habitName;
+    public void setTemplateName(String templateName) {
+        this.templateName = templateName;
+    }
+
+    public TemplateItem(@NonNull String userId, @NonNull String itemName, String templateName,
+                        String categoryName, String endTime, String startTime) {
+        this.userId = userId;
+        this.itemName = itemName;
+        this.templateName = templateName;
+        this.categoryName = categoryName;
+        this.endTime = endTime;
+        this.startTime = startTime;
     }
 
     public String getCategoryName() {

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/entity/User.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/entity/User.java
@@ -13,7 +13,17 @@ public class User {
     private String phone;
     private String pw;
     private String wx_id;
+
+    public String getAvatar() {
+        return avatar;
+    }
+
+    public void setAvatar(String avatar) {
+        this.avatar = avatar;
+    }
+
     private String qq_id;
+    private String avatar;
     //Room不允许有多个constructor,默认选用无参构造函数
 //    public User(String id) {
 //        this.id = id;

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/repository/TemplateItemRepository.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/repository/TemplateItemRepository.java
@@ -1,0 +1,81 @@
+package comv.example.zyrmj.precious_time01.repository;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+import androidx.lifecycle.LiveData;
+import androidx.room.Update;
+
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import comv.example.zyrmj.precious_time01.dao.TemplateItemDao;
+import comv.example.zyrmj.precious_time01.database.AppDatabase;
+import comv.example.zyrmj.precious_time01.entity.Template;
+import comv.example.zyrmj.precious_time01.entity.TemplateItem;
+
+public class TemplateItemRepository {
+    private LiveData<List<TemplateItem>>allTemplateItems;
+    private TemplateItemDao templateItemDao;
+    public TemplateItemRepository(Context context) {
+        AppDatabase appDatabase = AppDatabase.getDatabase(context.getApplicationContext());
+        templateItemDao = appDatabase.templateItemDao();
+        allTemplateItems = templateItemDao.getAllTemplateItems();
+    }
+
+    public LiveData<List<TemplateItem>> getAllTemplateItems() {
+        return allTemplateItems;
+    }
+
+    public void insertTemplateItems(TemplateItem... templateItems) {
+        new InsertAsyncTask(templateItemDao).execute(templateItems);
+    }
+    public void updateTemplateItems(TemplateItem... templateItems) {
+        new UpdateAsyncTask(templateItemDao).execute(templateItems);
+    }
+    public void deleteTemplateItems(TemplateItem... templateItems) {
+        new DeleteAsyncTask(templateItemDao).execute(templateItems);
+    }
+
+    static class InsertAsyncTask extends AsyncTask<TemplateItem, Void, Void> {
+        private TemplateItemDao templateItemDao;
+
+        public InsertAsyncTask(TemplateItemDao templateItemDao) {
+            this.templateItemDao = templateItemDao;
+        }
+
+        @Override
+        protected Void doInBackground(TemplateItem... templateItems) {
+            templateItemDao.insertTemplateItem(templateItems);
+            return null;
+        }
+    }
+
+    static class DeleteAsyncTask extends AsyncTask<TemplateItem, Void, Void> {
+        private TemplateItemDao templateItemDao;
+
+        public DeleteAsyncTask(TemplateItemDao templateItemDao) {
+            this.templateItemDao = templateItemDao;
+        }
+
+        @Override
+        protected Void doInBackground(TemplateItem... templateItems) {
+            templateItemDao.deleteTemplateItem(templateItems);
+            return null;
+        }
+    }
+
+    static class UpdateAsyncTask extends AsyncTask<TemplateItem, Void, Void> {
+        private TemplateItemDao templateItemDao;
+
+        public UpdateAsyncTask(TemplateItemDao templateItemDao) {
+            this.templateItemDao = templateItemDao;
+        }
+
+        @Override
+        protected Void doInBackground(TemplateItem... templateItems) {
+            templateItemDao.updateTemplateItem(templateItems);
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/repository/TemplateItemRepository.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/repository/TemplateItemRepository.java
@@ -4,14 +4,11 @@ import android.content.Context;
 import android.os.AsyncTask;
 
 import androidx.lifecycle.LiveData;
-import androidx.room.Update;
 
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 
 import comv.example.zyrmj.precious_time01.dao.TemplateItemDao;
 import comv.example.zyrmj.precious_time01.database.AppDatabase;
-import comv.example.zyrmj.precious_time01.entity.Template;
 import comv.example.zyrmj.precious_time01.entity.TemplateItem;
 
 public class TemplateItemRepository {
@@ -40,7 +37,7 @@ public class TemplateItemRepository {
     static class InsertAsyncTask extends AsyncTask<TemplateItem, Void, Void> {
         private TemplateItemDao templateItemDao;
 
-        public InsertAsyncTask(TemplateItemDao templateItemDao) {
+        private InsertAsyncTask(TemplateItemDao templateItemDao) {
             this.templateItemDao = templateItemDao;
         }
 
@@ -54,7 +51,7 @@ public class TemplateItemRepository {
     static class DeleteAsyncTask extends AsyncTask<TemplateItem, Void, Void> {
         private TemplateItemDao templateItemDao;
 
-        public DeleteAsyncTask(TemplateItemDao templateItemDao) {
+        private DeleteAsyncTask(TemplateItemDao templateItemDao) {
             this.templateItemDao = templateItemDao;
         }
 
@@ -68,7 +65,7 @@ public class TemplateItemRepository {
     static class UpdateAsyncTask extends AsyncTask<TemplateItem, Void, Void> {
         private TemplateItemDao templateItemDao;
 
-        public UpdateAsyncTask(TemplateItemDao templateItemDao) {
+        private UpdateAsyncTask(TemplateItemDao templateItemDao) {
             this.templateItemDao = templateItemDao;
         }
 

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/repository/TemplateRepository.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/repository/TemplateRepository.java
@@ -1,0 +1,77 @@
+package comv.example.zyrmj.precious_time01.repository;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+import androidx.lifecycle.LiveData;
+
+import java.util.List;
+
+import comv.example.zyrmj.precious_time01.dao.TemplateDao;
+import comv.example.zyrmj.precious_time01.dao.TemplateItemDao;
+import comv.example.zyrmj.precious_time01.database.AppDatabase;
+import comv.example.zyrmj.precious_time01.entity.Template;
+
+public class TemplateRepository {
+    private LiveData<List<Template>> allTemplates;
+    private TemplateDao templateDao;
+
+    public LiveData<List<Template>> getAllTemplates() {
+        return allTemplates;
+    }
+
+    public TemplateRepository(Context context) {
+        AppDatabase appDatabase = AppDatabase.getDatabase(context.getApplicationContext());
+        templateDao =  appDatabase.templateDao();
+        allTemplates = templateDao.getAllTemplates();
+    }
+
+    static class InsertAsyncTask extends AsyncTask<Template, Void, Void> {
+        private TemplateDao templateDao;
+
+        private InsertAsyncTask(TemplateDao templateDao) {
+            this.templateDao = templateDao;
+        }
+        @Override
+        protected Void doInBackground(Template... templates) {
+            templateDao.insertTemplate(templates);
+            return null;
+        }
+    }
+
+    static class UpdateAsyncTask extends AsyncTask<Template, Void, Void> {
+        private TemplateDao templateDao;
+
+        private UpdateAsyncTask(TemplateDao templateDao) {
+            this.templateDao = templateDao;
+        }
+        @Override
+        protected Void doInBackground(Template... templates) {
+            templateDao.updateTemplate(templates);
+            return null;
+        }
+    }
+
+    static class DeleteAsyncTask extends AsyncTask<Template, Void, Void> {
+        private TemplateDao templateDao;
+
+        private DeleteAsyncTask(TemplateDao templateDao) {
+            this.templateDao = templateDao;
+        }
+        @Override
+        protected Void doInBackground(Template... templates) {
+            templateDao.deleteTemplate(templates);
+            return null;
+        }
+    }
+
+    public void insertTemplates(Template... templates) {
+        new InsertAsyncTask(templateDao).execute(templates);
+    }
+    public void updateTemplates(Template... templates) {
+        new UpdateAsyncTask(templateDao).execute(templates);
+    }
+    public void deleteTemplates(Template... templates) {
+        new DeleteAsyncTask(templateDao).execute(templates);
+    }
+}

--- a/app/src/main/java/comv/example/zyrmj/precious_time01/repository/UserRepository.java
+++ b/app/src/main/java/comv/example/zyrmj/precious_time01/repository/UserRepository.java
@@ -1,0 +1,76 @@
+package comv.example.zyrmj.precious_time01.repository;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.provider.ContactsContract;
+import android.util.Log;
+
+import androidx.lifecycle.LiveData;
+
+import java.util.List;
+
+import comv.example.zyrmj.precious_time01.dao.UserDao;
+import comv.example.zyrmj.precious_time01.database.AppDatabase;
+import comv.example.zyrmj.precious_time01.entity.User;
+
+public class UserRepository {
+    private LiveData<List<User>> allUsers;
+    private UserDao userDao;
+
+    public LiveData<List<User>> getAllUsers() {
+        return allUsers;
+    }
+
+    public UserRepository(Context context) {
+        AppDatabase appDatabase = AppDatabase.getDatabase(context.getApplicationContext());
+        userDao = appDatabase.userDao();
+        allUsers = userDao.getAllUsers();
+    }
+
+    static class InsertAsyncTask extends AsyncTask<User, Void, Void> {
+        private UserDao userDao;
+        public InsertAsyncTask(UserDao userDao) {
+            this.userDao = userDao;
+        }
+        @Override
+        protected Void doInBackground(User... users) {
+            Log.d("user",users[0].getId());
+            userDao.insertUser(users);
+            return null;
+        }
+    }
+
+    static class UpdateAsyncTask extends AsyncTask<User, Void, Void> {
+        private UserDao userDao;
+        public UpdateAsyncTask(UserDao userDao) {
+            this.userDao = userDao;
+        }
+        @Override
+        protected Void doInBackground(User... users) {
+            userDao.updateUser(users);
+            return null;
+        }
+    }
+
+    static class DeleteAsyncTask extends AsyncTask<User, Void, Void> {
+        private UserDao userDao;
+        public DeleteAsyncTask(UserDao userDao) {
+            this.userDao = userDao;
+        }
+        @Override
+        protected Void doInBackground(User... users) {
+            userDao.deleteUser(users);
+            return null;
+        }
+    }
+
+    public void insertUsers(User... users) {
+        new InsertAsyncTask(userDao).execute(users);
+    }
+    public void updateUsers(User... users) {
+        new UpdateAsyncTask(userDao).execute(users);
+    }
+    public void DeleteUsers(User... users) {
+        new DeleteAsyncTask(userDao).execute(users);
+    }
+}


### PR DESCRIPTION
使用只需调用repository中对应的增删查改即可，不用生成数据库
具体使用样例在mainactivity中，第一次使用有效，第二次需注释掉，或卸载重装

清除了关于联合主键的外键约束，因为无法明确声明两个联合外键，需手动控制
具体地，一个TemplateItem在选择category和对应Template，必须指定已存在的category和Template，现在的数据库无法保证这一点